### PR TITLE
[limen GH-organvm-v-logos-github-21] Enable GitHub Discussions for community interaction

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: 💬 Community Discussions
+    url: https://github.com/organvm-v-logos/.github/discussions
+    about: "Ask questions, share ideas, and talk with the community — for anything that isn't a concrete bug or feature request"
   - name: ORGAN System Documentation
     url: https://github.com/meta-organvm/organvm-corpvs-testamentvm
     about: "Full system documentation and governance corpus"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ This organization covers: Essays, process documentation, methodology writing.
 - Documentation improvements
 - Performance optimizations
 - Security patches (see [SECURITY.md](SECURITY.md))
-- Feature proposals via Issues (discuss before implementing)
+- Feature proposals — float the idea in [Discussions](https://github.com/organvm-v-logos/.github/discussions) first, then open an Issue once there's a concrete plan
 
 ### What Requires Discussion First
 
@@ -53,7 +53,8 @@ Essay contributions must include YAML frontmatter (title, author, date, tags, ca
 
 ## Getting Help
 
-- Open an Issue for questions
+- Start a thread in [GitHub Discussions](https://github.com/organvm-v-logos/.github/discussions) for questions, ideas, or open-ended conversation
+- Open an Issue only for concrete bugs or actionable feature requests
 - Check existing documentation in each repo's README
 
 ## Review Service Targets

--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ Organization profile and community health files
 - Organization-level workflows
 - [Branch protection baseline](BRANCH_PROTECTION_BASELINE.md)
 - [README standards](README_STANDARDS.md)
+
+## Community
+
+Have a question, idea, or just want to talk shop? Join the conversation in
+**[GitHub Discussions](https://github.com/organvm-v-logos/.github/discussions)**.
+
+Discussions is the home for open-ended community interaction — questions, ideas,
+show-and-tell, and feedback on the public-process essays. Use [Issues](https://github.com/organvm-v-logos/.github/issues)
+for concrete bugs and feature requests, and Discussions for everything else.

--- a/profile/README.md
+++ b/profile/README.md
@@ -12,6 +12,10 @@ _Essays, case studies, and methodology documentation_
 
 **6 repositories · 40 published essays · ~130K words · [Read the essays →](https://organvm-v-logos.github.io/public-process/)**
 
+[![Join the Discussion](https://img.shields.io/badge/💬_Community-Discussions-0d47a1?style=flat-square)](https://github.com/organvm-v-logos/.github/discussions)
+
+_Building in public is a two-way street — **[join the conversation in Discussions →](https://github.com/organvm-v-logos/.github/discussions)**_
+
 </div>
 
 ---
@@ -49,6 +53,22 @@ This is not performative openness. ORGAN-V publishes because the process of buil
 | [.github](https://github.com/organvm-v-logos/.github) | Org profile and community health files | Infrastructure |
 
 The `public-process` repository is the primary venue for ORGAN-V content. It houses 40 long-form essays (2,000-5,000 words each, ~130K words total), organized by category (meta-system, case study, retrospective, guide). Its Jekyll site with RSS is live at **[organvm-v-logos.github.io/public-process](https://organvm-v-logos.github.io/public-process/)**. The four supporting repos provide autonomous essay pipeline automation (`essay-pipeline`), privacy-first engagement analytics (`analytics-engine`), editorial governance (`editorial-standards`), and curated intellectual context (`reading-observatory`).
+
+## Join the Conversation
+
+ORGAN-V publishes in the open, and the conversation around that work belongs in the
+open too. **[GitHub Discussions](https://github.com/organvm-v-logos/.github/discussions)**
+is the community square for the organization:
+
+- **💡 Ideas** — propose essay topics, methodology experiments, or system directions
+- **🙋 Q&A** — ask about the architecture, the essays, or how to contribute
+- **📣 Show & tell** — share what you're building or how the work influenced yours
+- **💬 General** — open-ended conversation about building in public
+
+Discussions complements — rather than replaces — the existing channels: use
+[Issues](https://github.com/organvm-v-logos/.github/issues) for concrete bugs and
+feature requests, and Discussions for everything open-ended. This is the place to
+talk back; the project is no longer broadcast-only.
 
 ## How ORGAN-V Fits the System
 


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GH-organvm-v-logos-github-21`.

GitHub issue organvm-v-logos/.github#21. Participants felt the project was broadcast-only and lacked a place for community interaction. Enabling and linking Discussions will help.

Refs: https://github.com/organvm-v-logos/.github/issues/21

_Produced in an isolated worktree off origin — review before merge._