### PR TITLE
[limen GH-organvm-dot-github-logos-21] Enable GitHub Discussions for community interaction

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Ask or discuss with the community
+    url: https://github.com/organvm/dot-github--logos/discussions
+    about: "Use GitHub Discussions for questions, open-ended ideas, reception notes, and community conversation"
   - name: ORGAN System Documentation
     url: https://github.com/meta-organvm/organvm-corpvs-testamentvm
     about: "Full system documentation and governance corpus"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,10 @@ By participating, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Ways to contribute
 
+- **Ask a question or start a conversation** — use
+  [GitHub Discussions](https://github.com/organvm/dot-github--logos/discussions)
+  for community interaction, open-ended ideas, and feedback that is not yet a
+  scoped change.
 - **Report a bug or suggest an idea** — open an [issue](../../issues). For
   anything large (a new essay topic, a change to the publishing workflow, an
   editorial policy update), open an issue to discuss it before writing code.
@@ -50,7 +54,10 @@ you're unsure.
 
 ## Getting help
 
-- Open an [issue](../../issues) with any question.
+- Start a
+  [GitHub Discussion](https://github.com/organvm/dot-github--logos/discussions)
+  with questions, reception notes, or open-ended feedback.
+- Open an [issue](../../issues) when the request is actionable and scoped.
 - Check the relevant repo's `README` — it's the source of truth for that repo's
   setup and workflow.
 

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -8,6 +8,10 @@ it locally?**
 > New to the organ itself? Read the [organization profile](profile/README.md)
 > for what ORGAN-V is and why it exists. This guide is purely operational.
 
+Community questions and open-ended feedback belong in
+[GitHub Discussions](https://github.com/organvm/dot-github--logos/discussions).
+Use issues for scoped bugs, documentation fixes, or implementation requests.
+
 ---
 
 ## 1. Which repository do I clone first?
@@ -101,6 +105,7 @@ Full details — accepted change types, review SLAs, development standards — a
 ## Where to go next
 
 - **[Organization profile](profile/README.md)** — what ORGAN-V is and how it fits the eight-organ system
+- **[GitHub Discussions](https://github.com/organvm/dot-github--logos/discussions)** — community questions, reception notes, and open-ended feedback
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — full contribution workflow and standards
 - **[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)** — community expectations
 - **[SECURITY.md](SECURITY.md)** — reporting vulnerabilities

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # .github
 Organization profile and community health files
 
+## Community Interaction
+
+Use [GitHub Discussions](https://github.com/organvm/dot-github--logos/discussions)
+for questions, open-ended ideas, reception notes, and community conversation.
+Use [issues](https://github.com/organvm/dot-github--logos/issues) for scoped
+bugs, documentation fixes, or implementation requests.
+
 ## Quick Start
 
 New here? **[Read the Quick Start guide →](QUICK_START.md)** — it explains which
@@ -13,5 +20,6 @@ repository to clone first and how to run things locally.
 - Organization-level workflows
 - [Branch protection baseline](BRANCH_PROTECTION_BASELINE.md)
 - [README standards](README_STANDARDS.md)
+- [GitHub Discussions](https://github.com/organvm/dot-github--logos/discussions) — community conversation and questions
 - [2026 distribution/conversion experiment synthesis](docs/logos/distribution-conversion-experiments-2026.md)
 - [Activation audit (2026-06-19)](docs/activation-audit-2026.md) — honest account of what is actually live

--- a/docs/external-validation/README.md
+++ b/docs/external-validation/README.md
@@ -77,12 +77,14 @@ secrets or full PII) in [revenue-ledger.md](revenue-ledger.md).
 
 ## How an external actor contributes
 
-- **Feedback:** open a
-  [Feedback issue](https://github.com/organvm-v-logos/.github/issues/new?template=external_feedback.yml)
-  or comment on any essay thread. Maintainer transcribes qualifying feedback
-  into the ledger.
-- **Events:** watch the org for announced sessions, or propose one via a
-  Feedback issue.
+- **Feedback:** start a
+  [GitHub Discussion](https://github.com/organvm/dot-github--logos/discussions)
+  or open a
+  [Feedback issue](https://github.com/organvm/dot-github--logos/issues/new?template=external_feedback.yml)
+  when the feedback is already specific and actionable. Maintainer transcribes
+  qualifying feedback into the ledger.
+- **Events:** watch the Discussions board for announced sessions, or propose one
+  in Discussions.
 - **Revenue:** book a consult, sponsor, or tip — see the
   [Consult page](https://4444j99.github.io/portfolio/consult/).
 

--- a/docs/external-validation/events-ledger.md
+++ b/docs/external-validation/events-ledger.md
@@ -15,7 +15,7 @@ record (thread, transcript, recording, recap, or attendee list).
 | — | — | — | — | — | _No event hosted yet._ | — |
 
 <!-- TEMPLATE ROW:
-| 1 | 2026-06-25 | Office hours (Discussions) | https://github.com/orgs/organvm-v-logos/discussions/NN | 3 | Thread + written recap | @maintainer |
+| 1 | 2026-06-25 | Office hours (Discussions) | https://github.com/organvm/dot-github--logos/discussions/NN | 3 | Thread + written recap | @maintainer |
 -->
 
 ## Hosting playbook (lowest-friction path)
@@ -23,7 +23,9 @@ record (thread, transcript, recording, recap, or attendee list).
 The cheapest event to host with a verifiable record is a **GitHub Discussions
 office-hours / AMA thread**:
 
-1. Enable Discussions on a public org repo (e.g. `public-process`) if not already.
+1. Use this repo's
+   [GitHub Discussions](https://github.com/organvm/dot-github--logos/discussions)
+   as the durable thread surface.
 2. Open a pinned thread: *"Open office hours — ask me anything about building an
    eight-organ system in public."* State a window (e.g. a 48-hour async AMA, or a
    live 1-hour slot) and a clear invitation.

--- a/docs/external-validation/feedback-ledger.md
+++ b/docs/external-validation/feedback-ledger.md
@@ -24,7 +24,10 @@ linkable source.
 - **Engagement ≠ feedback.** Stars, follows, reactions, and pageviews are tracked
   in [analytics-engine](https://github.com/organvm-v-logos/analytics-engine), not
   here.
-- To submit feedback, open an
-  [External Feedback issue](https://github.com/organvm-v-logos/.github/issues/new?template=external_feedback.yml).
+- To submit feedback, start a
+  [GitHub Discussion](https://github.com/organvm/dot-github--logos/discussions)
+  or open an
+  [External Feedback issue](https://github.com/organvm/dot-github--logos/issues/new?template=external_feedback.yml)
+  when the feedback is already specific and actionable.
 - When transcribing private feedback (e.g. email), record it only with the
   author's permission and link/quote the minimal verifiable excerpt.

--- a/profile/README.md
+++ b/profile/README.md
@@ -19,6 +19,10 @@ _Essays, case studies, and methodology documentation_
 > **New here?** The **[Quick Start guide](../QUICK_START.md)** tells you which
 > repository to clone first and how to run it locally.
 
+> **Want to talk back?** Start with
+> [GitHub Discussions](https://github.com/organvm/dot-github--logos/discussions)
+> for questions, community reception, and open-ended feedback.
+
 ## What Is ORGAN-V?
 
 ORGAN-V is the public-facing process layer of the [organvm system](https://github.com/meta-organvm) — an eight-organ creative-institutional architecture spanning theory, art, commerce, orchestration, community, marketing, and meta-governance.


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GH-organvm-dot-github-logos-21`.

GitHub issue organvm/dot-github--logos#21. Participants felt the project was broadcast-only and lacked a place for community interaction. Enabling and linking Discussions will help.

Refs: https://github.com/organvm/dot-github--logos/issues/21

_Produced in an isolated worktree off origin — review before merge._