### PR TITLE
[limen GH-organvm-dot-github-logos-17] Add 'Plain English' TL;DR to org profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -16,6 +16,14 @@ _Essays, case studies, and methodology documentation_
 
 ---
 
+## Plain English TL;DR
+
+ORGAN-V builds the public writing layer for the organvm project. It publishes
+essays about what the system is making, maintains tools that help draft and
+validate those essays, tracks lightweight readership signals, and keeps the
+editorial standards, reading lists, and GitHub profile that make the work easier
+to understand from the outside.
+
 > **New here?** The **[Quick Start guide](../QUICK_START.md)** tells you which
 > repository to clone first and how to run it locally.
 


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GH-organvm-dot-github-logos-17`.

GitHub issue organvm/dot-github--logos#17. Based on stranger tests, participants found the philosophical tone confusing and couldn't figure out what the org builds. We need a short, plain English summary at the top.

Refs: https://github.com/organvm/dot-github--logos/issues/17

_Produced in an isolated worktree off origin — review before merge._